### PR TITLE
Send IRC messages as notices, not channel messages

### DIFF
--- a/master.cfg
+++ b/master.cfg
@@ -372,6 +372,7 @@ c['services'] = []
 
 irc = reporters.IRC(host="irc.freenode.net", nick="gentoo-kernelci",
                     channels=["#gentoo-kernelci"],
+                    noticeOnChannel=True,
                     notify_events={
                         'started': 1,
                         'success': 1,


### PR DESCRIPTION
Buildbot 2.x
Signed-off-by: Michael Everitt <gentoo@veremit.xyz>